### PR TITLE
feat: OAuth2 소셜 로그인 + 이메일 인증 시스템 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ out/
 .env
 *.log
 
+# 로컬 OAuth/SMTP 시크릿 (절대 커밋 금지)
+application-local.yml
+**/application-local.yml
+
 # Kubernetes secrets
 *secret*.yaml
 *secret*.yml

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -14,6 +14,12 @@ const nextConfig = {
   },
   async rewrites() {
     return [
+      // user-service 이메일 인증 직접 프록시 (user-service: 8085)
+      {
+        source: '/api/users/:path*',
+        destination: 'http://localhost:8085/api/users/:path*',
+      },
+      // 그 외 모든 API → API Gateway (8080)
       {
         source: '/api/:path*',
         destination: 'http://localhost:8080/api/:path*',

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
+
+function CallbackContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
+  const [message, setMessage] = useState('소셜 로그인 처리 중...');
+
+  useEffect(() => {
+    const token = searchParams.get('token');
+    const refreshToken = searchParams.get('refreshToken');
+    const userId = searchParams.get('userId');
+    const name = searchParams.get('name');
+    const error = searchParams.get('error');
+
+    if (error) {
+      setStatus('error');
+      setMessage(
+        error === 'oauth2_failed' ? '소셜 로그인에 실패했습니다' :
+        error === 'email_not_found' ? '이메일 정보를 가져올 수 없습니다' :
+        '로그인 처리 중 오류가 발생했습니다'
+      );
+      setTimeout(() => router.push('/auth'), 2500);
+      return;
+    }
+
+    if (token && userId) {
+      localStorage.setItem('token', token);
+      if (refreshToken) localStorage.setItem('refreshToken', refreshToken);
+      localStorage.setItem('userId', userId);
+      if (name) localStorage.setItem('userName', decodeURIComponent(name));
+
+      setStatus('success');
+      setMessage(`환영합니다, ${decodeURIComponent(name || '회원')}님! 🎉`);
+
+      setTimeout(() => {
+        router.push('/');
+        window.location.reload();
+      }, 1200);
+    } else {
+      setStatus('error');
+      setMessage('토큰 정보가 없습니다. 다시 시도해주세요.');
+      setTimeout(() => router.push('/auth'), 2500);
+    }
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+      <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-10 text-center max-w-sm w-full mx-4">
+        {status === 'loading' && (
+          <>
+            <div className="w-14 h-14 border-4 border-red-200 border-t-red-600 rounded-full animate-spin mx-auto mb-5" />
+            <p className="text-gray-700 font-medium">{message}</p>
+          </>
+        )}
+        {status === 'success' && (
+          <>
+            <div className="text-5xl mb-4">🎉</div>
+            <h2 className="text-xl font-bold text-gray-900 mb-2">로그인 성공!</h2>
+            <p className="text-gray-500 text-sm">{message}</p>
+            <p className="text-xs text-gray-400 mt-2">홈으로 이동 중...</p>
+          </>
+        )}
+        {status === 'error' && (
+          <>
+            <div className="text-5xl mb-4">❌</div>
+            <h2 className="text-xl font-bold text-gray-900 mb-2">로그인 실패</h2>
+            <p className="text-gray-500 text-sm">{message}</p>
+            <p className="text-xs text-gray-400 mt-2">잠시 후 로그인 페이지로...</p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+        <div className="w-14 h-14 border-4 border-red-200 border-t-red-600 rounded-full animate-spin" />
+      </div>
+    }>
+      <CallbackContent />
+    </Suspense>
+  );
+}

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -1,55 +1,162 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 
+// user-service 포트: 8085 (OAuth2는 게이트웨이가 아닌 user-service 직접)
+const USER_SERVICE = 'http://localhost:8085';
+// API 프록시 (Next.js next.config.js → localhost:8080 → user-service)
+const API_BASE = '/api/users';
+
+type Mode = 'login' | 'signup';
+type SignupStep = 'form' | 'verify';
+
+interface FormState {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  name: string;
+  phone: string;
+  verifyCode: string;
+}
+
 export function AuthForm() {
   const router = useRouter();
-  const [mode, setMode] = useState<'login' | 'signup'>('login');
+  const [mode, setMode] = useState<Mode>('login');
+  const [signupStep, setSignupStep] = useState<SignupStep>('form');
   const [loading, setLoading] = useState(false);
-  const [form, setForm] = useState({ username: '', email: '', password: '', confirmPassword: '', name: '' });
+  const [sendingCode, setSendingCode] = useState(false);
+  const [codeSent, setCodeSent] = useState(false);
+  const [codeVerified, setCodeVerified] = useState(false);
+  const [countdown, setCountdown] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
 
-  const set = (k: string, v: string) => setForm(f => ({ ...f, [k]: v }));
+  const [form, setForm] = useState<FormState>({
+    email: '', password: '', confirmPassword: '', name: '', phone: '', verifyCode: '',
+  });
+  const set = (k: keyof FormState, v: string) => setForm(f => ({ ...f, [k]: v }));
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (mode === 'signup' && form.password !== form.confirmPassword) {
-      toast.error('비밀번호가 일치하지 않습니다'); return;
+  // ─── 인증 코드 발송 ─────────────────────────────────────────
+  const sendCode = async () => {
+    if (!form.email.includes('@')) { toast.error('올바른 이메일을 입력하세요'); return; }
+    setSendingCode(true);
+    try {
+      const res = await fetch(`${API_BASE}/email/send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: form.email }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || '전송 실패');
+
+      toast.success(`${form.email}로 인증 코드를 발송했습니다!`);
+      setCodeSent(true);
+      setCountdown(300); // 5분
+      clearInterval(timerRef.current);
+      timerRef.current = setInterval(() => {
+        setCountdown(c => {
+          if (c <= 1) { clearInterval(timerRef.current); return 0; }
+          return c - 1;
+        });
+      }, 1000);
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : '코드 전송 실패');
     }
+    setSendingCode(false);
+  };
+
+  // ─── 인증 코드 확인 ─────────────────────────────────────────
+  const verifyCode = async () => {
+    if (!form.verifyCode) { toast.error('인증 코드를 입력하세요'); return; }
     setLoading(true);
     try {
-      if (mode === 'login') {
-        const res = await fetch('/api/auth/login', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ username: form.username, password: form.password }),
-        });
-        if (!res.ok) throw new Error('로그인 실패');
-        const data = await res.json();
-        localStorage.setItem('token', data.accessToken || data.token || '');
-        localStorage.setItem('refreshToken', data.refreshToken || '');
-        localStorage.setItem('userId', String(data.userId || data.id || ''));
-        localStorage.setItem('userName', data.name || data.username || form.username);
-        toast.success('로그인되었습니다!');
-        router.push('/');
-        window.location.reload();
+      const res = await fetch(`${API_BASE}/email/verify`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: form.email, code: form.verifyCode }),
+      });
+      const data = await res.json();
+      if (data.verified) {
+        toast.success('이메일 인증 완료!');
+        setCodeVerified(true);
       } else {
-        const res = await fetch('/api/auth/register', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ username: form.username, email: form.email, password: form.password, name: form.name || form.username }),
-        });
-        if (!res.ok) {
-          const err = await res.json().catch(() => ({}));
-          throw new Error(err.message || '회원가입 실패');
-        }
-        toast.success('회원가입 완료! 로그인해주세요.');
-        setMode('login');
-        setForm(f => ({ ...f, password: '', confirmPassword: '' }));
+        toast.error(data.message || '인증 코드가 올바르지 않습니다');
       }
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : '오류가 발생했습니다');
+    } catch {
+      toast.error('인증 확인 중 오류');
     }
     setLoading(false);
+  };
+
+  // ─── 로그인 ─────────────────────────────────────────────────
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_BASE}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: form.email, password: form.password }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message || '이메일 또는 비밀번호가 올바르지 않습니다');
+      }
+      const data = await res.json();
+      localStorage.setItem('token', data.accessToken || data.token || '');
+      localStorage.setItem('refreshToken', data.refreshToken || '');
+      localStorage.setItem('userId', String(data.userId || data.id || ''));
+      localStorage.setItem('userName', data.name || data.username || form.email.split('@')[0]);
+      toast.success('로그인되었습니다!');
+      router.push('/');
+      window.location.reload();
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : '로그인 실패');
+    }
+    setLoading(false);
+  };
+
+  // ─── 회원가입 ────────────────────────────────────────────────
+  const handleSignup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!codeVerified) { toast.error('이메일 인증을 완료해주세요'); return; }
+    if (form.password !== form.confirmPassword) { toast.error('비밀번호가 일치하지 않습니다'); return; }
+    if (form.password.length < 8) { toast.error('비밀번호는 8자 이상이어야 합니다'); return; }
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_BASE}/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: form.email,
+          password: form.password,
+          name: form.name,
+          phoneNumber: form.phone || null,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message || '회원가입 실패');
+      }
+      toast.success('회원가입 완료! 로그인해주세요 🎉');
+      setMode('login');
+      setSignupStep('form');
+      setCodeSent(false);
+      setCodeVerified(false);
+      setForm(f => ({ ...f, password: '', confirmPassword: '', verifyCode: '' }));
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : '오류 발생');
+    }
+    setLoading(false);
+  };
+
+  const formatTime = (s: number) => `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`;
+
+  // ─── OAuth2 리다이렉트 ────────────────────────────────────────
+  const handleOAuth = (provider: 'kakao' | 'naver' | 'google') => {
+    // Spring Security OAuth2 표준 엔드포인트: user-service 직접 접근
+    window.location.href = `${USER_SERVICE}/oauth2/authorization/${provider}`;
   };
 
   return (
@@ -57,7 +164,7 @@ export function AuthForm() {
       <div className="w-full max-w-md">
         {/* 로고 */}
         <div className="text-center mb-8">
-          <a href="/" className="inline-block">
+          <a href="/">
             <span className="text-4xl font-black tracking-tight">
               <span className="text-red-600">Live</span><span className="text-gray-900">Mart</span>
             </span>
@@ -68,96 +175,173 @@ export function AuthForm() {
         <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
           {/* 탭 */}
           <div className="flex border-b border-gray-100">
-            <button
-              onClick={() => setMode('login')}
-              className={`flex-1 py-4 text-sm font-semibold transition-colors ${mode === 'login' ? 'text-red-600 border-b-2 border-red-600 -mb-px' : 'text-gray-500 hover:text-gray-700'}`}
-            >
-              로그인
-            </button>
-            <button
-              onClick={() => setMode('signup')}
-              className={`flex-1 py-4 text-sm font-semibold transition-colors ${mode === 'signup' ? 'text-red-600 border-b-2 border-red-600 -mb-px' : 'text-gray-500 hover:text-gray-700'}`}
-            >
-              회원가입
-            </button>
+            {(['login', 'signup'] as Mode[]).map(m => (
+              <button
+                key={m}
+                onClick={() => { setMode(m); setSignupStep('form'); setCodeSent(false); setCodeVerified(false); }}
+                className={`flex-1 py-4 text-sm font-semibold transition-colors ${mode === m ? 'text-red-600 border-b-2 border-red-600 -mb-px' : 'text-gray-500 hover:text-gray-700'}`}
+              >
+                {m === 'login' ? '로그인' : '회원가입'}
+              </button>
+            ))}
           </div>
 
-          <form onSubmit={handleSubmit} className="p-6 space-y-4">
-            {mode === 'signup' && (
-              <div>
-                <label className="form-label">이름</label>
-                <input type="text" value={form.name} onChange={e => set('name', e.target.value)}
-                  placeholder="홍길동" className="form-input" />
-              </div>
-            )}
-            <div>
-              <label className="form-label">아이디</label>
-              <input type="text" value={form.username} onChange={e => set('username', e.target.value)}
-                placeholder="아이디를 입력하세요" className="form-input" required />
-            </div>
-            {mode === 'signup' && (
+          {/* ─── 로그인 폼 ─── */}
+          {mode === 'login' && (
+            <form onSubmit={handleLogin} className="p-6 space-y-4">
               <div>
                 <label className="form-label">이메일</label>
                 <input type="email" value={form.email} onChange={e => set('email', e.target.value)}
-                  placeholder="example@email.com" className="form-input" />
+                  placeholder="example@email.com" className="form-input" required autoFocus />
               </div>
-            )}
-            <div>
-              <label className="form-label">비밀번호</label>
-              <input type="password" value={form.password} onChange={e => set('password', e.target.value)}
-                placeholder="비밀번호를 입력하세요" className="form-input" required />
-            </div>
-            {mode === 'signup' && (
               <div>
-                <label className="form-label">비밀번호 확인</label>
-                <input type="password" value={form.confirmPassword} onChange={e => set('confirmPassword', e.target.value)}
-                  placeholder="비밀번호를 다시 입력하세요" className="form-input" required />
+                <label className="form-label">비밀번호</label>
+                <input type="password" value={form.password} onChange={e => set('password', e.target.value)}
+                  placeholder="비밀번호를 입력하세요" className="form-input" required />
               </div>
-            )}
-
-            {mode === 'login' && (
               <div className="flex items-center justify-between text-sm">
                 <label className="flex items-center gap-2 text-gray-600 cursor-pointer">
                   <input type="checkbox" className="accent-red-600" /> 자동 로그인
                 </label>
                 <button type="button" className="text-red-600 hover:underline">비밀번호 찾기</button>
               </div>
-            )}
+              <button type="submit" disabled={loading}
+                className="w-full btn-primary py-3 text-base font-bold disabled:opacity-60 mt-2">
+                {loading ? <Spinner /> : '로그인'}
+              </button>
+            </form>
+          )}
 
-            {mode === 'signup' && (
+          {/* ─── 회원가입 폼 ─── */}
+          {mode === 'signup' && (
+            <form onSubmit={handleSignup} className="p-6 space-y-4">
+              {/* 이름 */}
+              <div>
+                <label className="form-label">이름 *</label>
+                <input type="text" value={form.name} onChange={e => set('name', e.target.value)}
+                  placeholder="홍길동" className="form-input" required />
+              </div>
+
+              {/* 이메일 + 인증 버튼 */}
+              <div>
+                <label className="form-label">이메일 *</label>
+                <div className="flex gap-2">
+                  <input type="email" value={form.email} onChange={e => { set('email', e.target.value); setCodeSent(false); setCodeVerified(false); }}
+                    placeholder="example@email.com" className="form-input flex-1"
+                    readOnly={codeVerified} required />
+                  <button type="button" onClick={sendCode}
+                    disabled={sendingCode || codeVerified || countdown > 0}
+                    className="btn-outline-red px-3 text-sm whitespace-nowrap disabled:opacity-50 flex-shrink-0">
+                    {codeVerified ? '✓인증됨' : sendingCode ? '발송중...' : codeSent && countdown > 0 ? `재발송(${formatTime(countdown)})` : '인증 요청'}
+                  </button>
+                </div>
+              </div>
+
+              {/* 인증 코드 입력 */}
+              {codeSent && !codeVerified && (
+                <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 space-y-3">
+                  <p className="text-sm text-blue-700 font-medium">
+                    📧 {form.email}로 인증 코드를 발송했습니다
+                    {countdown > 0 && <span className="ml-2 text-red-600 font-bold">{formatTime(countdown)}</span>}
+                  </p>
+                  <div className="flex gap-2">
+                    <input
+                      type="text" value={form.verifyCode}
+                      onChange={e => set('verifyCode', e.target.value.replace(/\D/g, '').slice(0, 6))}
+                      placeholder="6자리 코드 입력"
+                      className="form-input flex-1 text-center text-2xl tracking-widest font-bold"
+                      maxLength={6}
+                    />
+                    <button type="button" onClick={verifyCode}
+                      disabled={form.verifyCode.length !== 6 || loading}
+                      className="btn-primary px-4 disabled:opacity-50">
+                      {loading ? '확인중...' : '확인'}
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {codeVerified && (
+                <div className="flex items-center gap-2 text-green-600 bg-green-50 border border-green-200 rounded-lg p-3">
+                  <span className="text-lg">✅</span>
+                  <span className="text-sm font-medium">이메일 인증 완료!</span>
+                </div>
+              )}
+
+              {/* 전화번호 */}
+              <div>
+                <label className="form-label">전화번호</label>
+                <input type="tel" value={form.phone} onChange={e => set('phone', e.target.value)}
+                  placeholder="010-0000-0000" className="form-input" />
+              </div>
+
+              {/* 비밀번호 */}
+              <div>
+                <label className="form-label">비밀번호 * <span className="text-xs text-gray-400 font-normal">(8자 이상)</span></label>
+                <input type="password" value={form.password} onChange={e => set('password', e.target.value)}
+                  placeholder="비밀번호를 입력하세요" className="form-input" required />
+              </div>
+              <div>
+                <label className="form-label">비밀번호 확인 *</label>
+                <input type="password" value={form.confirmPassword} onChange={e => set('confirmPassword', e.target.value)}
+                  placeholder="비밀번호를 다시 입력하세요" className="form-input" required />
+                {form.confirmPassword && form.password !== form.confirmPassword && (
+                  <p className="text-xs text-red-500 mt-1">비밀번호가 일치하지 않습니다</p>
+                )}
+              </div>
+
               <p className="text-xs text-gray-400">
-                가입 시 LiveMart의 <span className="text-red-500 cursor-pointer hover:underline">이용약관</span> 및{' '}
+                가입 시 <span className="text-red-500 cursor-pointer hover:underline">이용약관</span> 및{' '}
                 <span className="text-red-500 cursor-pointer hover:underline">개인정보 처리방침</span>에 동의하게 됩니다.
               </p>
-            )}
 
-            <button type="submit" disabled={loading}
-              className="w-full btn-primary py-3 text-base font-bold disabled:opacity-60 disabled:cursor-not-allowed mt-2">
-              {loading ? (
-                <span className="flex items-center justify-center gap-2">
-                  <svg className="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
-                  </svg>
-                  처리중...
-                </span>
-              ) : mode === 'login' ? '로그인' : '회원가입'}
-            </button>
-          </form>
+              <button type="submit" disabled={loading || !codeVerified}
+                className="w-full btn-primary py-3 text-base font-bold disabled:opacity-60 mt-2">
+                {loading ? <Spinner /> : !codeVerified ? '이메일 인증 후 가입 가능' : '회원가입'}
+              </button>
+            </form>
+          )}
 
-          {/* 소셜 로그인 */}
+          {/* ─── 소셜 로그인 ─── */}
           <div className="px-6 pb-6">
             <div className="flex items-center gap-3 mb-4">
               <div className="flex-1 h-px bg-gray-100" />
-              <span className="text-xs text-gray-400">또는</span>
+              <span className="text-xs text-gray-400">소셜 계정으로 {mode === 'login' ? '로그인' : '가입'}</span>
               <div className="flex-1 h-px bg-gray-100" />
             </div>
-            <div className="grid grid-cols-2 gap-3">
-              <button className="flex items-center justify-center gap-2 py-2.5 border border-gray-200 rounded-lg text-sm text-gray-700 hover:bg-yellow-50 hover:border-yellow-300 transition-colors font-medium">
-                <span className="text-base">💛</span> 카카오
+            <div className="grid grid-cols-3 gap-3">
+              {/* 카카오 */}
+              <button
+                onClick={() => handleOAuth('kakao')}
+                className="flex flex-col items-center gap-1.5 py-3 rounded-xl border-2 border-[#FEE500] bg-[#FEE500] hover:bg-[#F4D400] transition-colors"
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="#3A1D1D">
+                  <path d="M12 3C6.477 3 2 6.477 2 10.727c0 2.648 1.695 4.98 4.273 6.383l-.97 3.545c-.087.32.29.58.57.38l4.175-2.754c.636.085 1.29.128 1.952.128 5.523 0 10-3.477 10-7.682C22 6.477 17.523 3 12 3z"/>
+                </svg>
+                <span className="text-xs font-bold text-[#3A1D1D]">카카오</span>
               </button>
-              <button className="flex items-center justify-center gap-2 py-2.5 border border-gray-200 rounded-lg text-sm text-gray-700 hover:bg-green-50 hover:border-green-300 transition-colors font-medium">
-                <span className="text-base">🟢</span> 네이버
+
+              {/* 네이버 */}
+              <button
+                onClick={() => handleOAuth('naver')}
+                className="flex flex-col items-center gap-1.5 py-3 rounded-xl border-2 border-[#03C75A] bg-[#03C75A] hover:bg-[#02B34F] transition-colors"
+              >
+                <span className="text-white text-lg font-black leading-none" style={{ fontFamily: 'sans-serif' }}>N</span>
+                <span className="text-xs font-bold text-white">네이버</span>
+              </button>
+
+              {/* 구글 */}
+              <button
+                onClick={() => handleOAuth('google')}
+                className="flex flex-col items-center gap-1.5 py-3 rounded-xl border-2 border-gray-200 bg-white hover:bg-gray-50 transition-colors"
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24">
+                  <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                  <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                  <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+                  <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                </svg>
+                <span className="text-xs font-medium text-gray-700">Google</span>
               </button>
             </div>
           </div>
@@ -172,5 +356,17 @@ export function AuthForm() {
         </p>
       </div>
     </div>
+  );
+}
+
+function Spinner() {
+  return (
+    <span className="flex items-center justify-center gap-2">
+      <svg className="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
+      </svg>
+      처리중...
+    </span>
   );
 }

--- a/user-service/src/main/java/com/livemart/user/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/livemart/user/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.livemart.user.config;
 
+import com.livemart.user.oauth.CustomOAuth2UserService;
+import com.livemart.user.oauth.OAuth2SuccessHandler;
 import com.livemart.user.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +14,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -20,6 +27,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -27,27 +36,52 @@ public class SecurityConfig {
     }
 
     @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(
+            "http://localhost:3000", "http://localhost:3001", "http://localhost:3002"
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
-                .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/api/users/signup",
-                                "/api/users/login",
-                                "/api/users/refresh",
-                                "/api/users/health",
-                                "/actuator/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/api-docs/**",
-                                "/v3/api-docs/**"
-                        ).permitAll()
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                        .anyRequest().authenticated()
-                )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .csrf(csrf -> csrf.disable())
+            // OAuth2는 세션 필요, IF_REQUIRED 사용
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    "/api/users/signup",
+                    "/api/users/login",
+                    "/api/users/refresh",
+                    "/api/users/health",
+                    "/api/users/email/**",   // 이메일 인증
+                    "/oauth2/**",            // OAuth2 진입점
+                    "/login/oauth2/**",      // OAuth2 콜백
+                    "/actuator/**",
+                    "/swagger-ui/**",
+                    "/swagger-ui.html",
+                    "/api-docs/**",
+                    "/v3/api-docs/**"
+                ).permitAll()
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                .anyRequest().authenticated()
+            )
+            .oauth2Login(oauth2 -> oauth2
+                .userInfoEndpoint(userInfo -> userInfo
+                    .userService(customOAuth2UserService))
+                .successHandler(oAuth2SuccessHandler)
+                .failureUrl("http://localhost:3000/auth?error=oauth2_failed")
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/user-service/src/main/java/com/livemart/user/controller/UserController.java
+++ b/user-service/src/main/java/com/livemart/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.livemart.user.controller;
 
 import com.livemart.user.dto.*;
+import com.livemart.user.service.EmailVerificationService;
 import com.livemart.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +13,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @Tag(name = "User API", description = "사용자 관리 API")
 @RestController
 @RequestMapping("/api/users")
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final EmailVerificationService emailVerificationService;
 
     @Operation(summary = "회원가입")
     @PostMapping("/signup")
@@ -64,5 +68,42 @@ public class UserController {
     @GetMapping("/health")
     public ResponseEntity<String> health() {
         return ResponseEntity.ok("User Service is running");
+    }
+
+    // ─── 이메일 인증 ──────────────────────────────────────────────
+
+    @Operation(summary = "이메일 인증 코드 발송")
+    @PostMapping("/email/send")
+    public ResponseEntity<Map<String, String>> sendVerificationEmail(@RequestBody Map<String, String> body) {
+        String email = body.get("email");
+        if (email == null || email.isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("message", "이메일을 입력해주세요"));
+        }
+        try {
+            emailVerificationService.sendVerificationCode(email);
+            return ResponseEntity.ok(Map.of("message", "인증 코드가 전송되었습니다"));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    @Operation(summary = "이메일 인증 코드 확인")
+    @PostMapping("/email/verify")
+    public ResponseEntity<Map<String, Object>> verifyEmail(@RequestBody Map<String, String> body) {
+        String email = body.get("email");
+        String code = body.get("code");
+
+        if (email == null || code == null) {
+            return ResponseEntity.badRequest().body(Map.of("verified", false, "message", "이메일과 코드를 입력해주세요"));
+        }
+
+        boolean verified = emailVerificationService.verifyCode(email, code);
+        if (verified) {
+            return ResponseEntity.ok(Map.of("verified", true, "message", "인증이 완료되었습니다"));
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("verified", false, "message", "인증 코드가 올바르지 않거나 만료되었습니다"));
+        }
     }
 }

--- a/user-service/src/main/java/com/livemart/user/dto/EmailVerificationRequest.java
+++ b/user-service/src/main/java/com/livemart/user/dto/EmailVerificationRequest.java
@@ -1,0 +1,17 @@
+package com.livemart.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailVerificationRequest {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+
+    private String code; // 검증 시에만 필요
+}

--- a/user-service/src/main/java/com/livemart/user/oauth/OAuth2SuccessHandler.java
+++ b/user-service/src/main/java/com/livemart/user/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,78 @@
+package com.livemart.user.oauth;
+
+import com.livemart.user.domain.User;
+import com.livemart.user.repository.UserRepository;
+import com.livemart.user.security.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * OAuth2 로그인 성공 핸들러
+ * JWT 토큰 생성 후 프론트엔드로 리다이렉트
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @Value("${oauth2.redirect-uri:http://localhost:3000/auth/callback}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        // CustomOAuth2User에서 email 추출
+        String email = null;
+        if (oAuth2User instanceof CustomOAuth2User customUser) {
+            email = customUser.getEmail();
+        } else {
+            email = (String) oAuth2User.getAttributes().get("email");
+        }
+
+        if (email == null) {
+            log.error("OAuth2 login: email not found in principal");
+            response.sendRedirect(redirectUri + "?error=email_not_found");
+            return;
+        }
+
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user == null) {
+            log.error("OAuth2 login: user not found for email={}", email);
+            response.sendRedirect(redirectUri + "?error=user_not_found");
+            return;
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getEmail(), user.getRole().name());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+        log.info("OAuth2 login success: userId={}, email={}", user.getId(), email);
+
+        String redirectUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("token", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .queryParam("userId", user.getId())
+                .queryParam("name", URLEncoder.encode(user.getName(), StandardCharsets.UTF_8))
+                .build().toUriString();
+
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/user-service/src/main/java/com/livemart/user/service/EmailVerificationService.java
+++ b/user-service/src/main/java/com/livemart/user/service/EmailVerificationService.java
@@ -1,0 +1,106 @@
+package com.livemart.user.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private final JavaMailSender mailSender;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String CODE_PREFIX = "email:verify:";
+    private static final long CODE_EXPIRE_MINUTES = 5;
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    /** 인증 코드 생성 후 이메일 발송, Redis에 5분 저장 */
+    public void sendVerificationCode(String email) {
+        String code = generateCode();
+        String key = CODE_PREFIX + email;
+
+        redisTemplate.opsForValue().set(key, code, CODE_EXPIRE_MINUTES, TimeUnit.MINUTES);
+
+        try {
+            sendEmail(email, code);
+            log.info("Email verification code sent: email={}", email);
+        } catch (Exception e) {
+            redisTemplate.delete(key);
+            log.error("Failed to send verification email: email={}, error={}", email, e.getMessage());
+            throw new RuntimeException("이메일 전송에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    /** 코드 검증 */
+    public boolean verifyCode(String email, String inputCode) {
+        String key = CODE_PREFIX + email;
+        String storedCode = redisTemplate.opsForValue().get(key);
+
+        if (storedCode == null) {
+            log.warn("Verification code not found or expired: email={}", email);
+            return false;
+        }
+
+        boolean match = storedCode.equals(inputCode.trim());
+        if (match) {
+            redisTemplate.delete(key); // 인증 완료 후 삭제
+            log.info("Email verification successful: email={}", email);
+        } else {
+            log.warn("Invalid verification code: email={}", email);
+        }
+        return match;
+    }
+
+    private String generateCode() {
+        return String.format("%06d", RANDOM.nextInt(1_000_000));
+    }
+
+    private void sendEmail(String to, String code) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        helper.setTo(to);
+        helper.setSubject("[LiveMart] 이메일 인증 코드");
+        helper.setText(buildEmailHtml(code), true); // HTML 메일
+
+        mailSender.send(message);
+    }
+
+    private String buildEmailHtml(String code) {
+        return """
+            <!DOCTYPE html>
+            <html>
+            <body style="font-family: 'Apple SD Gothic Neo', sans-serif; background:#f5f5f5; margin:0; padding:20px;">
+              <div style="max-width:480px; margin:0 auto; background:#fff; border-radius:16px; overflow:hidden; box-shadow:0 4px 20px rgba(0,0,0,0.08);">
+                <div style="background:#E11D48; padding:28px 32px;">
+                  <h1 style="color:#fff; margin:0; font-size:22px; font-weight:900; letter-spacing:-0.5px;">
+                    <span style="font-weight:400;">Live</span>Mart
+                  </h1>
+                </div>
+                <div style="padding:32px;">
+                  <h2 style="color:#111; margin:0 0 8px; font-size:20px;">이메일 인증 코드</h2>
+                  <p style="color:#555; margin:0 0 24px; font-size:14px;">아래 6자리 코드를 입력해주세요. 코드는 5분간 유효합니다.</p>
+                  <div style="background:#fff5f7; border:2px solid #E11D48; border-radius:12px; padding:24px; text-align:center;">
+                    <span style="font-size:40px; font-weight:900; color:#E11D48; letter-spacing:8px;">%s</span>
+                  </div>
+                  <p style="color:#888; margin:24px 0 0; font-size:12px;">본인이 요청하지 않은 경우 이 이메일을 무시하세요.</p>
+                </div>
+                <div style="background:#f9f9f9; padding:16px 32px; text-align:center;">
+                  <p style="color:#aaa; margin:0; font-size:12px;">© 2025 LiveMart. All rights reserved.</p>
+                </div>
+              </div>
+            </body>
+            </html>
+            """.formatted(code);
+    }
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -28,8 +28,80 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  # ─── 이메일 (네이버 SMTP) ─────────────────────────────────────
+  mail:
+    host: smtp.naver.com
+    port: 587
+    username: ${SMTP_USERNAME:swaw5a@naver.com}
+    password: ${SMTP_PASSWORD:tlqkf12}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    default-encoding: UTF-8
+
+  # ─── OAuth2 소셜 로그인 ───────────────────────────────────────
+  security:
+    oauth2:
+      client:
+        registration:
+          # 카카오 로그인 (Client Secret 미사용)
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: none
+            scope:
+              - profile_nickname
+              - account_email
+            client-name: Kakao
+
+          # 네이버 로그인
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+              - email
+            client-name: Naver
+
+          # 구글 로그인
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - profile
+              - email
+            client-name: Google
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
 
 server:
   port: 8085
@@ -38,6 +110,10 @@ jwt:
   secret: ${JWT_SECRET:your-secret-key-must-be-at-least-256-bits-long-for-HS256-algorithm-security}
   expiration: 86400000
   refresh-expiration: 604800000
+
+# OAuth2 성공 후 프론트엔드 리다이렉트 URI
+oauth2:
+  redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/auth/callback}
 
 management:
   endpoints:
@@ -62,7 +138,6 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /api-docs
-
 
 eureka:
   client:


### PR DESCRIPTION
- 네이버/카카오/구글 OAuth2 로그인 통합 (실제 Client ID/Secret 적용)
- 이메일 인증 코드 발송 (Naver SMTP) 및 검증 API 추가
- OAuth2 성공 핸들러 → JWT 발급 후 프론트 콜백 리다이렉트
- Spring Security OAuth2 설정 (CORS, 세션, 허용 경로)
- AuthForm.tsx: 이메일 기반 로그인 + 인증 코드 입력 UI + 소셜 버튼
- auth/callback/page.tsx: OAuth 토큰 수신 후 localStorage 저장
- next.config.js: /api/users/* → user-service(8085) 직접 프록시 추가