### PR TITLE
feat: OAuth2 소셜 로그인 개선 + 이메일 인증 수정 + 관리자 유저 관리 + 온보딩 페이지

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "livemart-frontend",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["./node_modules/.bin/next", "dev", "--turbopack", "-p", "3002"],
+      "port": 3002
+    },
+    {
+      "name": "livemart-user-service",
+      "runtimeExecutable": "cmd",
+      "runtimeArgs": ["/c", "D:\\project\\livemart-clean\\gradlew.bat", "-p", "D:\\project\\livemart-clean", ":user-service:bootRun", "--args=--spring.profiles.active=local", "--no-build-cache"],
+      "port": 8085
+    }
+  ]
+}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import toast from 'react-hot-toast';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+const API_BASE = 'http://localhost:8085';
 
 interface User {
   id: number;
@@ -25,14 +25,27 @@ export default function AdminUsersPage() {
     setLoading(true);
     try {
       const token = localStorage.getItem('token') || '';
+      if (!token) {
+        toast.error('로그인이 필요합니다. 관리자 계정으로 로그인해주세요.');
+        setLoading(false);
+        return;
+      }
       const res = await fetch(`${API_BASE}/api/users`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (res.ok) {
         const data = await res.json();
         setUsers(Array.isArray(data) ? data : data.content || []);
+      } else if (res.status === 401) {
+        toast.error('세션이 만료됐습니다. 다시 로그인해주세요.');
+        window.location.href = '/auth';
+      } else if (res.status === 403) {
+        toast.error('관리자 권한이 없습니다. ADMIN 계정으로 로그인해주세요.');
+      } else {
+        toast.error('유저 목록을 불러오지 못했습니다.');
       }
     } catch {
+      toast.error('서버에 연결할 수 없습니다.');
       setUsers([]);
     }
     setLoading(false);

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -34,13 +34,22 @@ function CallbackContent() {
       localStorage.setItem('userId', userId);
       if (name) localStorage.setItem('userName', decodeURIComponent(name));
 
-      setStatus('success');
-      setMessage(`환영합니다, ${decodeURIComponent(name || '회원')}님! 🎉`);
+      const needOnboarding = searchParams.get('needOnboarding') === 'true';
 
-      setTimeout(() => {
-        router.push('/');
-        window.location.reload();
-      }, 1200);
+      if (needOnboarding) {
+        // 최초 소셜 로그인 → 추가 정보 입력 페이지로 이동
+        setStatus('success');
+        setMessage('추가 정보를 입력해주세요 ✍️');
+        setTimeout(() => {
+          window.location.href = '/auth/onboarding';
+        }, 800);
+      } else {
+        setStatus('success');
+        setMessage(`환영합니다, ${decodeURIComponent(name || '회원')}님! 🎉`);
+        setTimeout(() => {
+          window.location.href = '/';
+        }, 1200);
+      }
     } else {
       setStatus('error');
       setMessage('토큰 정보가 없습니다. 다시 시도해주세요.');

--- a/frontend/src/app/auth/onboarding/page.tsx
+++ b/frontend/src/app/auth/onboarding/page.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+const API_BASE = 'http://localhost:8085';
+
+export default function OnboardingPage() {
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [agreeTerms, setAgreeTerms] = useState(false);
+  const [agreeMarketing, setAgreeMarketing] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      window.location.href = '/auth';
+      return;
+    }
+    const savedName = localStorage.getItem('userName');
+    if (savedName) setName(savedName);
+  }, []);
+
+  // 010-XXXX-XXXX 형식 자동 포맷
+  const formatPhone = (value: string) => {
+    const digits = value.replace(/\D/g, '').slice(0, 11);
+    if (digits.length <= 3) return digits;
+    if (digits.length <= 7) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+    return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+  };
+
+  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPhone(formatPhone(e.target.value));
+    setError('');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!agreeTerms) {
+      setError('서비스 이용약관에 동의해주세요.');
+      return;
+    }
+    const rawPhone = phone.replace(/-/g, '');
+    if (rawPhone.length < 10 || !rawPhone.startsWith('01')) {
+      setError('올바른 휴대폰 번호를 입력해주세요. (예: 010-1234-5678)');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      const token = localStorage.getItem('token');
+      const res = await fetch(`${API_BASE}/api/users/me`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ name, phoneNumber: phone }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        // 이름 업데이트된 경우 localStorage 갱신
+        if (data.name) localStorage.setItem('userName', data.name);
+        window.location.href = '/';
+      } else if (res.status === 401) {
+        window.location.href = '/auth';
+      } else {
+        setError('정보 저장에 실패했습니다. 다시 시도해주세요.');
+      }
+    } catch {
+      setError('서버 연결에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    }
+
+    setLoading(false);
+  };
+
+  const handleSkip = () => {
+    window.location.href = '/';
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-red-50 to-gray-50 flex items-center justify-center px-4 py-10">
+      <div className="w-full max-w-md">
+
+        {/* 로고 */}
+        <div className="text-center mb-8">
+          <a href="/" className="inline-block mb-4">
+            <span className="text-3xl font-black tracking-tight">
+              <span className="text-red-600">Live</span>
+              <span className="text-gray-900">Mart</span>
+            </span>
+          </a>
+          {/* 진행 단계 표시 */}
+          <div className="flex items-center justify-center gap-2 mb-5">
+            <div className="w-8 h-1.5 rounded-full bg-gray-200" />
+            <div className="w-8 h-1.5 rounded-full bg-red-500" />
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">추가 정보 입력</h1>
+          <p className="text-sm text-gray-500 mt-1.5">
+            원활한 쇼핑을 위해 아래 정보를 입력해주세요
+          </p>
+        </div>
+
+        {/* 폼 카드 */}
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 space-y-5"
+        >
+          {/* 이름 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1.5">
+              이름
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="홍길동"
+              className="w-full px-4 py-3 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition"
+              required
+            />
+          </div>
+
+          {/* 휴대폰 번호 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1.5">
+              휴대폰 번호 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="tel"
+              value={phone}
+              onChange={handlePhoneChange}
+              placeholder="010-0000-0000"
+              maxLength={13}
+              inputMode="numeric"
+              className="w-full px-4 py-3 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition"
+              required
+            />
+            <p className="text-xs text-gray-400 mt-1">배송지 확인 및 본인 인증에 사용됩니다</p>
+          </div>
+
+          {/* 약관 동의 */}
+          <div className="bg-gray-50 rounded-xl p-4 space-y-3">
+            <p className="text-sm font-semibold text-gray-700">약관 동의</p>
+
+            {/* 전체 동의 */}
+            <label className="flex items-center gap-3 cursor-pointer group">
+              <input
+                type="checkbox"
+                checked={agreeTerms && agreeMarketing}
+                onChange={(e) => {
+                  setAgreeTerms(e.target.checked);
+                  setAgreeMarketing(e.target.checked);
+                }}
+                className="w-4 h-4 rounded border-gray-300 text-red-600 focus:ring-red-500 cursor-pointer"
+              />
+              <span className="text-sm font-medium text-gray-800 group-hover:text-red-600 transition-colors">
+                전체 동의
+              </span>
+            </label>
+
+            <div className="border-t border-gray-200 pt-3 space-y-2.5">
+              {/* 필수 약관 */}
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={agreeTerms}
+                  onChange={(e) => setAgreeTerms(e.target.checked)}
+                  className="mt-0.5 w-4 h-4 rounded border-gray-300 text-red-600 focus:ring-red-500 cursor-pointer"
+                />
+                <span className="text-sm text-gray-600">
+                  <span className="text-red-500 font-medium">[필수] </span>
+                  서비스 이용약관 및 개인정보처리방침 동의
+                </span>
+              </label>
+
+              {/* 선택 약관 */}
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={agreeMarketing}
+                  onChange={(e) => setAgreeMarketing(e.target.checked)}
+                  className="mt-0.5 w-4 h-4 rounded border-gray-300 text-red-600 focus:ring-red-500 cursor-pointer"
+                />
+                <span className="text-sm text-gray-600">
+                  <span className="text-gray-400">[선택] </span>
+                  마케팅 정보 수신 동의 (이벤트·할인·혜택 안내)
+                </span>
+              </label>
+            </div>
+          </div>
+
+          {/* 에러 메시지 */}
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+              <p className="text-sm text-red-600">{error}</p>
+            </div>
+          )}
+
+          {/* 완료 버튼 */}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full py-3.5 bg-red-600 hover:bg-red-700 active:bg-red-800 text-white font-semibold rounded-xl transition-colors disabled:opacity-60 disabled:cursor-not-allowed text-sm"
+          >
+            {loading ? (
+              <span className="flex items-center justify-center gap-2">
+                <svg className="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                저장 중...
+              </span>
+            ) : (
+              'LiveMart 시작하기 →'
+            )}
+          </button>
+
+          {/* 나중에 하기 */}
+          <button
+            type="button"
+            onClick={handleSkip}
+            className="w-full py-2 text-xs text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            나중에 입력할게요
+          </button>
+        </form>
+
+        <p className="text-center text-xs text-gray-400 mt-5">
+          입력하신 정보는 안전하게 보호됩니다 🔒
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -109,8 +109,7 @@ export function AuthForm() {
       localStorage.setItem('userId', String(data.userId || data.id || ''));
       localStorage.setItem('userName', data.name || data.username || form.email.split('@')[0]);
       toast.success('로그인되었습니다!');
-      router.push('/');
-      window.location.reload();
+      window.location.href = '/';
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : '로그인 실패');
     }

--- a/frontend/src/components/GlobalNav.tsx
+++ b/frontend/src/components/GlobalNav.tsx
@@ -37,10 +37,19 @@ export function GlobalNav() {
     if (searchQuery.trim()) router.push(`/search?q=${encodeURIComponent(searchQuery.trim())}`);
   };
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    // 1. Spring Security 서버 세션 무효화 (OAuth2 자동 재인증 방지)
+    try {
+      await fetch('http://localhost:8085/api/users/session-logout', {
+        method: 'POST',
+        credentials: 'include',  // JSESSIONID 쿠키 전송
+      });
+    } catch (_) {
+      // 서버 오류여도 로컬 로그아웃은 진행
+    }
+    // 2. 로컬 토큰 삭제
     ['token', 'refreshToken', 'userId', 'userName', 'apiKey'].forEach(k => localStorage.removeItem(k));
-    router.push('/');
-    window.location.reload();
+    window.location.href = '/';
   };
 
   return (

--- a/user-service/src/main/java/com/livemart/user/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/livemart/user/config/SecurityConfig.java
@@ -3,7 +3,10 @@ package com.livemart.user.config;
 import com.livemart.user.oauth.CustomOAuth2UserService;
 import com.livemart.user.oauth.OAuth2SuccessHandler;
 import com.livemart.user.security.JwtAuthenticationFilter;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -12,6 +15,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -30,6 +38,12 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
+    @Autowired
+    private ClientRegistrationRepository clientRegistrationRepository;
+
+    @Value("${oauth2.redirect-uri:http://localhost:3002/auth/callback}")
+    private String oauth2RedirectUri;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -41,7 +55,7 @@ public class SecurityConfig {
         config.setAllowedOrigins(List.of(
             "http://localhost:3000", "http://localhost:3001", "http://localhost:3002"
         ));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
@@ -54,6 +68,8 @@ public class SecurityConfig {
         http
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(csrf -> csrf.disable())
+            // Form 로그인 비활성화 (JWT + OAuth2만 사용)
+            .formLogin(AbstractHttpConfigurer::disable)
             // OAuth2는 세션 필요, IF_REQUIRED 사용
             .sessionManagement(session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
@@ -66,6 +82,7 @@ public class SecurityConfig {
                     "/api/users/email/**",   // 이메일 인증
                     "/oauth2/**",            // OAuth2 진입점
                     "/login/oauth2/**",      // OAuth2 콜백
+                    "/api/users/session-logout", // 세션 로그아웃 (비인증 허용)
                     "/actuator/**",
                     "/swagger-ui/**",
                     "/swagger-ui.html",
@@ -75,14 +92,68 @@ public class SecurityConfig {
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
             )
+            .logout(logout -> logout
+                .logoutUrl("/api/users/session-logout")
+                .invalidateHttpSession(true)          // 서버 세션 무효화
+                .clearAuthentication(true)            // SecurityContext 초기화
+                .deleteCookies("JSESSIONID")          // 세션 쿠키 삭제
+                .logoutSuccessHandler((request, response, authentication) -> {
+                    response.setStatus(HttpServletResponse.SC_OK);
+                })
+            )
             .oauth2Login(oauth2 -> oauth2
+                .authorizationEndpoint(endpoint -> endpoint
+                    .authorizationRequestResolver(oAuth2AuthorizationRequestResolver()))
                 .userInfoEndpoint(userInfo -> userInfo
                     .userService(customOAuth2UserService))
                 .successHandler(oAuth2SuccessHandler)
-                .failureUrl("http://localhost:3000/auth?error=oauth2_failed")
+                .failureHandler((request, response, exception) -> {
+                    String baseUrl = oauth2RedirectUri.replaceAll("/auth/callback.*", "");
+                    response.sendRedirect(baseUrl + "/auth?error=oauth2_failed");
+                })
+            )
+            // API 요청은 JSON 401/403 반환 (브라우저 리다이렉트 방지)
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint((request, response, authException) -> {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write("{\"error\":\"Unauthorized\",\"message\":\"로그인이 필요합니다\"}");
+                })
+                .accessDeniedHandler((request, response, accessDeniedException) -> {
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write("{\"error\":\"Forbidden\",\"message\":\"접근 권한이 없습니다\"}");
+                })
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    /**
+     * OAuth2 인증 요청 커스터마이저
+     * - Google: prompt=select_account → 항상 계정 선택 화면 표시
+     * - Kakao:  prompt=login         → 항상 재로그인 화면 표시
+     * - Naver:  auth_type=reauthenticate (선택적)
+     */
+    private OAuth2AuthorizationRequestResolver oAuth2AuthorizationRequestResolver() {
+        DefaultOAuth2AuthorizationRequestResolver resolver =
+            new DefaultOAuth2AuthorizationRequestResolver(
+                clientRegistrationRepository, "/oauth2/authorization");
+
+        resolver.setAuthorizationRequestCustomizer(customizer -> {
+            String registrationId = (String) customizer.build()
+                .getAttributes().get(OAuth2ParameterNames.REGISTRATION_ID);
+
+            if ("google".equals(registrationId)) {
+                // 항상 계정 선택 화면 (로그아웃 후 다른 계정으로 로그인 가능)
+                customizer.additionalParameters(p -> p.put("prompt", "select_account"));
+            } else if ("kakao".equals(registrationId)) {
+                // 항상 카카오 재로그인 화면 표시
+                customizer.additionalParameters(p -> p.put("prompt", "login"));
+            }
+        });
+
+        return resolver;
     }
 }

--- a/user-service/src/main/java/com/livemart/user/controller/UserController.java
+++ b/user-service/src/main/java/com/livemart/user/controller/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @Tag(name = "User API", description = "사용자 관리 API")
@@ -57,6 +58,15 @@ public class UserController {
         return ResponseEntity.ok(userService.getUserById(userId));
     }
 
+    @Operation(summary = "내 프로필 수정 (온보딩·추가정보)")
+    @PatchMapping("/me")
+    public ResponseEntity<UserResponse> updateMyProfile(
+            Authentication authentication,
+            @RequestBody UpdateProfileRequest request) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(userService.updateMyProfile(userId, request));
+    }
+
     @Operation(summary = "사용자 조회")
     @GetMapping("/{userId}")
     @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal")
@@ -68,6 +78,36 @@ public class UserController {
     @GetMapping("/health")
     public ResponseEntity<String> health() {
         return ResponseEntity.ok("User Service is running");
+    }
+
+    // ─── 관리자 전용 ──────────────────────────────────────────────
+
+    @Operation(summary = "전체 사용자 목록 조회 (관리자)")
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<UserResponse>> getAllUsers() {
+        return ResponseEntity.ok(userService.getAllUsers());
+    }
+
+    @Operation(summary = "사용자 역할 변경 (관리자)")
+    @PutMapping("/{userId}/role")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<UserResponse> updateUserRole(
+            @PathVariable Long userId,
+            @RequestBody Map<String, String> body) {
+        String role = body.get("role");
+        if (role == null || role.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(userService.updateUserRole(userId, role));
+    }
+
+    @Operation(summary = "사용자 비활성화 (관리자)")
+    @DeleteMapping("/{userId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deactivateUser(@PathVariable Long userId) {
+        userService.deactivateUser(userId);
+        return ResponseEntity.noContent().build();
     }
 
     // ─── 이메일 인증 ──────────────────────────────────────────────

--- a/user-service/src/main/java/com/livemart/user/domain/User.java
+++ b/user-service/src/main/java/com/livemart/user/domain/User.java
@@ -122,4 +122,12 @@ public class User {
     public boolean isMfaEnabled() {
         return mfaEnabled != null && mfaEnabled;
     }
+
+    public void updateRole(UserRole newRole) {
+        this.role = newRole;
+    }
+
+    public void deactivate() {
+        this.status = UserStatus.INACTIVE;
+    }
 }

--- a/user-service/src/main/java/com/livemart/user/dto/UpdateProfileRequest.java
+++ b/user-service/src/main/java/com/livemart/user/dto/UpdateProfileRequest.java
@@ -1,0 +1,13 @@
+package com.livemart.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProfileRequest {
+    private String name;
+    private String phoneNumber;
+}

--- a/user-service/src/main/java/com/livemart/user/oauth/KakaoOAuth2UserInfo.java
+++ b/user-service/src/main/java/com/livemart/user/oauth/KakaoOAuth2UserInfo.java
@@ -26,10 +26,12 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
     @Override
     public String getEmail() {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        if (kakaoAccount == null) {
-            return null;
+        if (kakaoAccount != null) {
+            String email = (String) kakaoAccount.get("email");
+            if (email != null && !email.isEmpty()) return email;
         }
-        return (String) kakaoAccount.get("email");
+        // 이메일 권한 없는 경우 providerId로 고유 이메일 생성
+        return "kakao_" + getProviderId() + "@kakao.local";
     }
 
     @Override

--- a/user-service/src/main/java/com/livemart/user/oauth/OAuth2SuccessHandler.java
+++ b/user-service/src/main/java/com/livemart/user/oauth/OAuth2SuccessHandler.java
@@ -64,13 +64,17 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getEmail(), user.getRole().name());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
-        log.info("OAuth2 login success: userId={}, email={}", user.getId(), email);
+        // 휴대폰 번호가 없으면 온보딩 필요
+        boolean needOnboarding = user.getPhoneNumber() == null || user.getPhoneNumber().isBlank();
+
+        log.info("OAuth2 login success: userId={}, email={}, needOnboarding={}", user.getId(), email, needOnboarding);
 
         String redirectUrl = UriComponentsBuilder.fromUriString(redirectUri)
                 .queryParam("token", accessToken)
                 .queryParam("refreshToken", refreshToken)
                 .queryParam("userId", user.getId())
                 .queryParam("name", URLEncoder.encode(user.getName(), StandardCharsets.UTF_8))
+                .queryParam("needOnboarding", needOnboarding)
                 .build().toUriString();
 
         response.sendRedirect(redirectUrl);

--- a/user-service/src/main/java/com/livemart/user/repository/UserRepository.java
+++ b/user-service/src/main/java/com/livemart/user/repository/UserRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/user-service/src/main/java/com/livemart/user/service/EmailVerificationService.java
+++ b/user-service/src/main/java/com/livemart/user/service/EmailVerificationService.java
@@ -4,6 +4,7 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -19,6 +20,9 @@ public class EmailVerificationService {
 
     private final JavaMailSender mailSender;
     private final StringRedisTemplate redisTemplate;
+
+    @Value("${spring.mail.username}")
+    private String senderEmail;
 
     private static final String CODE_PREFIX = "email:verify:";
     private static final long CODE_EXPIRE_MINUTES = 5;
@@ -69,6 +73,7 @@ public class EmailVerificationService {
         MimeMessage message = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
+        helper.setFrom(senderEmail);
         helper.setTo(to);
         helper.setSubject("[LiveMart] 이메일 인증 코드");
         helper.setText(buildEmailHtml(code), true); // HTML 메일

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -54,15 +54,15 @@ spring:
     oauth2:
       client:
         registration:
-          # 카카오 로그인 (Client Secret 미사용)
+          # 카카오 로그인
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
-            client-authentication-method: none
+            client-authentication-method: client_secret_post
             scope:
               - profile_nickname
-              - account_email
             client-name: Kakao
 
           # 네이버 로그인
@@ -113,7 +113,7 @@ jwt:
 
 # OAuth2 성공 후 프론트엔드 리다이렉트 URI
 oauth2:
-  redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/auth/callback}
+  redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3002/auth/callback}
 
 management:
   endpoints:


### PR DESCRIPTION
[user-service] OAuth2 소셜 로그인
- CustomOAuth2UserService: provider+providerId 3단계 조회로 username 중복 키 오류 해결
- UserRepository: findByProviderAndProviderId 메서드 추가
- KakaoOAuth2UserInfo: 이메일 없을 때 kakao_{id}@kakao.local fallback 처리
- OAuth2SuccessHandler: needOnboarding 파라미터 추가 (전화번호 없는 신규 유저 감지)

[user-service] SecurityConfig
- formLogin 비활성화, PATCH 메서드 CORS 허용 추가
- 인증 실패 시 302 리다이렉트 → JSON 401/403 응답으로 변경
- session logout 설정 + OAuth2 prompt=login/select_account 커스터마이저 추가

[user-service] 관리자 API
- UserController: GET /api/users, PUT /{id}/role, DELETE /{id}, PATCH /me 추가
- UserService: getAllUsers, updateUserRole, deactivateUser, updateMyProfile 추가
- User 도메인: updateRole, deactivate 메서드 추가
- UpdateProfileRequest DTO 추가

[user-service] 이메일 인증 SMTP 수정
- EmailVerificationService: setFrom(senderEmail) 추가로 554 발신자 오류 해결
- application.yml: CORS allowedMethods에 PATCH 추가

[frontend] 소셜 로그인 흐름 개선
- auth/callback/page.tsx: needOnboarding 분기 → 온보딩 페이지 이동
- auth/onboarding/page.tsx: 신규 유저 추가 정보 입력 페이지 (전화번호 + 약관 동의) 추가
- admin/users/page.tsx: API 주소 8085 직접 호출, 401/403 에러 핸들링 추가
- GlobalNav.tsx: 로그아웃 시 서버 session-logout 호출 + window.location.href 적용
- AuthForm.tsx: 로그인 성공 후 window.location.href로 무한루프 방지