### PR TITLE
[fix] AI 챗봇 무한 로딩 및 우편번호 CSP 오류 수정

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -179,6 +179,9 @@ services:
       - PORT=8090
       - REDIS_URL=${REDIS_URL}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+      - SPRING_AI_OPENAI_API_KEY=${OPENROUTER_API_KEY}
+      - SPRING_AI_OPENAI_BASE_URL=https://openrouter.ai/api/v1
+      - SPRING_AI_OPENAI_CHAT_OPTIONS_MODEL=google/gemma-3-27b-it:free
       - SPRING_MAIN_ALLOW_BEAN_DEFINITION_OVERRIDING=true
       - SPRING_CLOUD_COMPATIBILITY_VERIFIER_ENABLED=false
     restart: unless-stopped

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -47,7 +47,7 @@ const nextConfig = {
               "font-src 'self' https://fonts.gstatic.com https://*.daumcdn.net https://*.kakaocdn.net",
               "img-src 'self' data: blob: https://cdn.livemart.com http://localhost:* https:",
               "connect-src 'self' http://localhost:* ws://localhost:* https://api.livemart.com https://*.tosspayments.com https://t1.daumcdn.net https://*.kakaocdn.net https://*.daum.net",
-              "frame-src https://js.tosspayments.com https://pay.toss.im https://postcode.map.daum.net https://*.daumcdn.net https://*.kakaocdn.net",
+              "frame-src https://js.tosspayments.com https://pay.toss.im https://postcode.map.daum.net https://postcode.map.kakao.com https://*.daumcdn.net https://*.kakaocdn.net",
               "frame-ancestors 'self'",
               "base-uri 'self'",
               "form-action 'self'",

--- a/frontend/src/app/_components/AiChatbot.client.tsx
+++ b/frontend/src/app/_components/AiChatbot.client.tsx
@@ -103,6 +103,11 @@ export function AiChatbot() {
             // "data:" 접두사(5자) 제거 → 실제 토큰 추출
             const token = line.slice(5);
             if (token === '[DONE]') continue;
+            if (token === '[ERROR]') {
+              accumulated = '__ERROR__';
+              hasNewContent = true;
+              continue;
+            }
             accumulated += token;
             hasNewContent = true;
           }
@@ -120,8 +125,8 @@ export function AiChatbot() {
         }
       }
 
-      // 스트림 종료 후 content가 비어있으면 에러 메시지로 교체
-      if (!accumulated) {
+      // 스트림 종료 후 content가 비어있거나 에러이면 에러 메시지로 교체
+      if (!accumulated || accumulated === '__ERROR__') {
         setMessages(prev => {
           const updated = [...prev];
           updated[updated.length - 1] = {

--- a/frontend/src/app/_components/AiChatbot.client.tsx
+++ b/frontend/src/app/_components/AiChatbot.client.tsx
@@ -120,6 +120,18 @@ export function AiChatbot() {
         }
       }
 
+      // 스트림 종료 후 content가 비어있으면 에러 메시지로 교체
+      if (!accumulated) {
+        setMessages(prev => {
+          const updated = [...prev];
+          updated[updated.length - 1] = {
+            ...updated[updated.length - 1],
+            content: '죄송합니다. AI 서비스에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.',
+          };
+          return updated;
+        });
+      }
+
       // 세션 ID가 없으면 서버에서 새로 받기
       if (!sessionId) {
         const nonStreamRes = await fetch('/api/ai/chat', {

--- a/frontend/src/app/api/ai/chat/stream/route.ts
+++ b/frontend/src/app/api/ai/chat/stream/route.ts
@@ -42,7 +42,9 @@ export async function POST(request: NextRequest) {
             }
           }
           controller.enqueue(encoder.encode('data:[DONE]\n'));
-        } catch {
+        } catch (e) {
+          console.error('[AI stream error]', e);
+          controller.enqueue(encoder.encode('data:[ERROR]\n'));
           controller.enqueue(encoder.encode('data:[DONE]\n'));
         } finally {
           controller.close();

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "devDependencies": {
     "puppeteer": "^24.37.5"
+  },
+  "dependencies": {
+    "playwright": "^1.59.1"
   }
 }


### PR DESCRIPTION
## Summary
- AI 챗봇 스트림 에러 원인 파악을 위한 로깅 추가 (`[AI stream error]` Vercel 로그 출력)
- 스트림 종료 후 content 비어있을 때 "..." 무한 표시 → 에러 메시지로 교체
- CSP frame-src에 `postcode.map.kakao.com` 추가 (우편번호 iframe 차단 해결)
- docker-compose.prod.yml ai-service에 `SPRING_AI_OPENAI_*` 환경변수 추가

## 변경된 서비스
- frontend / api-gateway

## Test
Vercel 재배포 후 AI 챗봇 및 우편번호 검색 동작 확인